### PR TITLE
Odoo v14.0 has no icon menuitem_attr

### DIFF
--- a/jitsi_meet/views/jitsi_meet_views.xml
+++ b/jitsi_meet/views/jitsi_meet_views.xml
@@ -71,8 +71,7 @@
             id="menu_meeting"
             web_icon="jitsi_meet,static/description/web_cam.jpg"
             sequence="99"
-            action="action_meeting"
-            icon="STOCK_ZOOM_IN"/>
+            action="action_meeting"/>
         <record model='ir.ui.menu' id='menu_meeting'>
             <field name="groups_id" eval="[(6,0,[ref('base.group_user')])]"/>
         </record>


### PR DESCRIPTION
For Odoo v14.0 compatibility, icon attribute should not be used in menuitem tag.